### PR TITLE
Deactivate vaccine demographic data scrapers

### DIFF
--- a/can_tools/__init__.py
+++ b/can_tools/__init__.py
@@ -80,8 +80,4 @@ ACTIVE_SCRAPERS = [
     scrapers.HawaiiVaccineCounty,
     scrapers.NCVaccineCounty,
     scrapers.NCVaccineState,
-    # Demographic data scrapers
-    *[scraper for scraper in ALL_SCRAPERS if scraper.demographic_data == True],
-    # Monkeypox scrapers
-    scrapers.CDCCurrentMonkeypoxCases,
 ]


### PR DESCRIPTION
Per our API docs we will be sunsetting demographic data after [2/15/2023](https://apidocs.covidactnow.org/updates#sunsetting-demographic-vaccine-data). As such, these scrapers will no longer be needed. 

A cleanup/follow-up chore would be to delete all the unused scrapers, but this current change will prevent the scrapers from being picked up by Prefect.