### PR TITLE
fix cache url for CDC county cases scraper

### DIFF
--- a/can_tools/scrapers/official/federal/CDC/cdc_county_cases_deaths.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_county_cases_deaths.py
@@ -26,7 +26,9 @@ class CDCCountyCasesDeaths(FederalDashboard, ETagCacheMixin):
 
     def __init__(self, execution_dt: pd.Timestamp = pd.Timestamp.utcnow()):
         ETagCacheMixin.initialize_cache(
-            self, cache_url=self.fetch_url, cache_file="cdc_county_cases_deaths.txt"
+            self,
+            cache_url=self.fetch_url.format(county_fips="06075"),
+            cache_file="cdc_county_cases_deaths.txt",
         )
         super().__init__(execution_dt=execution_dt)
 


### PR DESCRIPTION
The cache URL previously wasn't being interpolated with a county, so the URL was invalid and the etag would never change.  

There's no great way with the current setup to tell whether or not any of the URLs have updated, so this just checks a random county (SF) and assumes that all the counties update with the same cadence.